### PR TITLE
Fix bug in program on homepage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -17,7 +17,7 @@ array of 64-bit floating-point numbers:
 
 .. code-block:: Futhark
 
-  let average (xs: []f64) = reduce (+) 0.0 xs / r64 (length xs)
+  let average (xs: []f64) = reduce (+) 0.0 xs / f64.i64 (length xs)
 
 .. container:: quicklinks
 


### PR DESCRIPTION
I think this one slipped through the cracks with the transition from i32 to i64.

When compiling with futhark version 0.19.0

  ```futhark 
let average (xs: []f64) = reduce (+) 0.0 xs / r64 (length xs)
```
I get the classic bug
```bash
Error at lol.fut:1:51-61:
Cannot apply "r64" to "(length xs)" (invalid type).
Expected: i32
Actual:   i64
```
So I just switched `r64` to `f64.i64`

Probably best that the first example futhark program is bug free!

