### PR TITLE
Replace let with def in function example

### DIFF
--- a/examples/functions.fut
+++ b/examples/functions.fut
@@ -1,6 +1,6 @@
 -- # Functions
 --
--- Functions are defined with `let`, where we can also annotate both
+-- Functions are defined with `def`, where we can also annotate both
 -- the parameter and return types.
 
 def plus2 (x: i32) : i32 =


### PR DESCRIPTION
Recently got interested in Futhark, noticed the examples for functions mentioned using the deprecated `let` instead of `def`