### PR TITLE
Switch Kahan summation example to proper markdown title

### DIFF
--- a/examples/kahan.fut
+++ b/examples/kahan.fut
@@ -1,4 +1,4 @@
--- $ Kahan summation
+-- # Kahan summation
 --
 -- Summation of floating-point numbers is vulnerable to roundoff
 -- error.  The [Kahan summation


### PR DESCRIPTION
Before:
<img width="877" alt="Screen Shot 2022-01-15 at 19 51 20" src="https://user-images.githubusercontent.com/8095395/149643020-64a3c62e-8c88-4aa3-b0bc-fe8b4cbe657e.png">

After:
<img width="870" alt="Screen Shot 2022-01-15 at 19 51 42" src="https://user-images.githubusercontent.com/8095395/149643024-e1d62320-bc4f-4232-a11d-f7234175c170.png">