### PR TITLE
Updated blur-png.py

### DIFF
--- a/static/blur-png.py
+++ b/static/blur-png.py
@@ -2,17 +2,23 @@
 
 import blur
 import numpy
-from scipy import misc
 import argparse
+
+import imageio
 
 def main(infile, outfile, iterations):
     b = blur.blur()
-    img = misc.imread(infile, mode='RGB')
-    (height, width, channels) = img.shape
+    img = imageio.v2.imread(infile, pilmode="RGB")
+    img = imageio.core.asarray(img)
+    img = img / 2
+    img = img.astype(numpy.uint8)
+    
     blurred = b.main(iterations, img)
+    blurred = blurred * 2
+    
     # The .get() is to retrieve a Numpy array from the PyOpenCL array
     # being returned.
-    misc.imsave(outfile, blurred.get().astype(numpy.uint8))
+    imageio.imwrite(outfile, blurred.get().astype(numpy.uint8))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple Gaussian blur of a PNG file.')


### PR DESCRIPTION
Replaced scipy.misc.imread and imwrite with calls to imageio as the former was deprecated and removed.
Note how the image is divided by two and later, after the blur, scaled back up. Otherwise most values in the blurred image will be 127.

This fixes https://github.com/diku-dk/futhark/issues/1688